### PR TITLE
在调用Arrays.binarySearch(）之前需要确定数组为升序，即必须先调用Arrays.sort()

### DIFF
--- a/project/Libraries/DroidPlugin/src/com/morgoo/droidplugin/pm/IPluginManagerImpl.java
+++ b/project/Libraries/DroidPlugin/src/com/morgoo/droidplugin/pm/IPluginManagerImpl.java
@@ -1279,11 +1279,14 @@ public class IPluginManagerImpl extends IPluginManager.Stub {
         List<RunningAppProcessInfo> infos = am.getRunningAppProcesses();
         boolean success = false;
         for (RunningAppProcessInfo info : infos) {
-            Arrays.sort(info.pkgList);
-            if (info.pkgList != null && Arrays.binarySearch(info.pkgList, pluginPackageName) >= 0 && info.pid != android.os.Process.myPid()) {
-                Log.i(TAG, "killBackgroundProcesses(%s),pkgList=%s,pid=%s", pluginPackageName, Arrays.toString(info.pkgList), info.pid);
-                android.os.Process.killProcess(info.pid);
-                success = true;
+            if (info.pkgList != null) {
+                String[] pkgListCopy = info.pkgList.clone();
+                Arrays.sort(pkgListCopy);
+                if (Arrays.binarySearch(pkgListCopy, pluginPackageName) >= 0 && info.pid != android.os.Process.myPid()) {
+                    Log.i(TAG, "killBackgroundProcesses(%s),pkgList=%s,pid=%s", pluginPackageName, Arrays.toString(info.pkgList), info.pid);
+                    android.os.Process.killProcess(info.pid);
+                    success = true;
+                }
             }
         }
         return success;

--- a/project/Libraries/DroidPlugin/src/com/morgoo/droidplugin/pm/IPluginManagerImpl.java
+++ b/project/Libraries/DroidPlugin/src/com/morgoo/droidplugin/pm/IPluginManagerImpl.java
@@ -1279,6 +1279,7 @@ public class IPluginManagerImpl extends IPluginManager.Stub {
         List<RunningAppProcessInfo> infos = am.getRunningAppProcesses();
         boolean success = false;
         for (RunningAppProcessInfo info : infos) {
+            Arrays.sort(info.pkgList);
             if (info.pkgList != null && Arrays.binarySearch(info.pkgList, pluginPackageName) >= 0 && info.pid != android.os.Process.myPid()) {
                 Log.i(TAG, "killBackgroundProcesses(%s),pkgList=%s,pid=%s", pluginPackageName, Arrays.toString(info.pkgList), info.pid);
                 android.os.Process.killProcess(info.pid);

--- a/project/Libraries/DroidPlugin/src/com/morgoo/droidplugin/pm/IPluginManagerImpl.java
+++ b/project/Libraries/DroidPlugin/src/com/morgoo/droidplugin/pm/IPluginManagerImpl.java
@@ -1280,7 +1280,7 @@ public class IPluginManagerImpl extends IPluginManager.Stub {
         boolean success = false;
         for (RunningAppProcessInfo info : infos) {
             if (info.pkgList != null) {
-                String[] pkgListCopy = info.pkgList.clone();
+                String[] pkgListCopy = Arrays.copyOf(info.pkgList, info.pkgList.length);
                 Arrays.sort(pkgListCopy);
                 if (Arrays.binarySearch(pkgListCopy, pluginPackageName) >= 0 && info.pid != android.os.Process.myPid()) {
                     Log.i(TAG, "killBackgroundProcesses(%s),pkgList=%s,pid=%s", pluginPackageName, Arrays.toString(info.pkgList), info.pid);


### PR DESCRIPTION
解决在某些情况下killBackgroundProcesses不生效的问题。
ref: java source