### PR TITLE
修复64位手机插件无法加载so库问题

### DIFF
--- a/project/Libraries/DroidPlugin/build.gradle
+++ b/project/Libraries/DroidPlugin/build.gradle
@@ -17,7 +17,7 @@ android {
             renderscript.srcDirs = ['src']
             res.srcDirs = ['res']
             assets.srcDirs = ['assets']
-            jniLibs.srcDirs = ['libs']
+            jniLibs.srcDirs = ['jniLibs']
         }
 
         instrumentTest.setRoot('tests')


### PR DESCRIPTION
目前发现64位手机（如小米note）插件无法加载so库，我发现可以预先在DroidPlugin中预先放置一个空的armeabi \ libplugin.so，让系统默认以32位方式打开so库，即可解决问题。