### PR TITLE
restore targetIntent for target Activity's onNewIntent() in PluginIns…

### DIFF
--- a/project/Libraries/DroidPlugin/src/com/morgoo/droidplugin/hook/handle/PluginInstrumentation.java
+++ b/project/Libraries/DroidPlugin/src/com/morgoo/droidplugin/hook/handle/PluginInstrumentation.java
@@ -212,6 +212,7 @@ public class PluginInstrumentation extends Instrumentation {
 
     @Override
     public void callActivityOnNewIntent(Activity activity, Intent intent) {
+        intent = intent.getParcelableExtra(Env.EXTRA_TARGET_INTENT);
         if (activity != null && intent != null) {
             intent.setClassName(activity.getPackageName(), activity.getClass().getName());
         }


### PR DESCRIPTION
…trumenation.

we save origin intent in startActivity, at the same time we MUST restore for onNewIntent() if
launch mode is singleTask, singleTop or singleInstance as we do for standard launch mode in
 PluginCallback.handleLauncherActivity().