### PR TITLE
startActivityForResult的intent如果有FLAG_ACTIVITY_NEW_TASK无法正常使用

### DIFF
--- a/project/Libraries/DroidPlugin/src/com/morgoo/droidplugin/hook/handle/IActivityManagerHookHandle.java
+++ b/project/Libraries/DroidPlugin/src/com/morgoo/droidplugin/hook/handle/IActivityManagerHookHandle.java
@@ -184,7 +184,7 @@ public class IActivityManagerHookHandle extends BaseHookHandle {
 
                         String callingPackage = (String) args[1];
                         if (TextUtils.equals(mHostContext.getPackageName(), callingPackage)) {
-                            newIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+//                            newIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 //                            if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP && activityInfo.launchMode == ActivityInfo.LAUNCH_MULTIPLE) {
 //                                newIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_DOCUMENT);
 //                            }


### PR DESCRIPTION
暂时测试并修改了>18版本方法,修改后,在团队的多部>18的android手机上可正常使用startActivity,startActivityForResult等方法, 该方法中设置FLAG_ACTIVITY_NEW_TASK应该是考虑了Service打开Activity的情况, 所以实际应该先考虑是Service或者Activity调用,来确定这个标志的设置与否